### PR TITLE
Updated read/writes of datetime to store/retrieve as UTC time.

### DIFF
--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2764,7 +2764,7 @@ namespace SQLite
 
 		internal static IntPtr NegativePointer = new IntPtr (-1);
 
-		const string DateTimeExactStoreFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff";
+	    const string DateTimeExactStoreFormat = "yyyy-MM-ddTHH:mm:ss.fffffffZ";
 
 		internal static void BindParameter (Sqlite3Statement stmt, int index, object value, bool storeDateTimeAsTicks)
 		{
@@ -2795,10 +2795,10 @@ namespace SQLite
 				}
 				else if (value is DateTime) {
 					if (storeDateTimeAsTicks) {
-						SQLite3.BindInt64 (stmt, index, ((DateTime)value).Ticks);
+						SQLite3.BindInt64 (stmt, index, ((DateTime)value).ToUniversalTime().Ticks);
 					}
 					else {
-						SQLite3.BindText (stmt, index, ((DateTime)value).ToString (DateTimeExactStoreFormat, System.Globalization.CultureInfo.InvariantCulture), -1, NegativePointer);
+						SQLite3.BindText (stmt, index, ((DateTime)value).ToUniversalTime().ToString (DateTimeExactStoreFormat, System.Globalization.CultureInfo.InvariantCulture), -1, NegativePointer);
 					}
 				}
 				else if (value is DateTimeOffset) {
@@ -2873,7 +2873,7 @@ namespace SQLite
 				}
 				else if (clrType == typeof (DateTime)) {
 					if (_conn.StoreDateTimeAsTicks) {
-						return new DateTime (SQLite3.ColumnInt64 (stmt, index));
+						return new DateTime (SQLite3.ColumnInt64 (stmt, index), DateTimeKind.Utc);
 					}
 					else {
 						var text = SQLite3.ColumnString (stmt, index);
@@ -2881,7 +2881,7 @@ namespace SQLite
 						if (!DateTime.TryParseExact (text, DateTimeExactStoreFormat, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out resultDate)) {
 							resultDate = DateTime.Parse (text);
 						}
-						return resultDate;
+						return resultDate.ToUniversalTime();
 					}
 				}
 				else if (clrType == typeof (DateTimeOffset)) {

--- a/tests/DateTimeTest.cs
+++ b/tests/DateTimeTest.cs
@@ -62,10 +62,11 @@ namespace SQLite.Tests
 			// Ticks
 			//
 			o = new TestObj {
-				ModifiedTime = new DateTime (2012, 1, 14, 3, 2, 1, 234),
+				ModifiedTime = new DateTime (2012, 1, 14, 3, 2, 1, 234, DateTimeKind.Utc),
 			};
 			db.InsertAsync (o).Wait ();
 			o2 = db.GetAsync<TestObj> (o.Id).Result;
+			Assert.AreEqual (DateTimeKind.Utc, o2.ModifiedTime.Kind);
 			Assert.AreEqual (o.ModifiedTime, o2.ModifiedTime);
 		}
 
@@ -79,7 +80,7 @@ namespace SQLite.Tests
 			// Ticks
 			//
 			o = new TestObj {
-				ModifiedTime = new DateTime (2012, 1, 14, 3, 2, 1, 234),
+				ModifiedTime = new DateTime (2012, 1, 14, 3, 2, 1, 234, DateTimeKind.Utc),
 			};
 			db.Insert (o);
 			o2 = db.Get<TestObj> (o.Id);


### PR DESCRIPTION
Prior to this we used the oysteinkrog fork which stored/retrieved data as UTC time.

We are updating to use this (praeclarum) version and have made a similar change in SQLite.cs to implement that behavior.