### PR TITLE
TR-3206 - Pull in 1.5 from Upstream Parent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,9 +12,6 @@ indent_style = space
 indent_size = 4
 end_of_line = lf
 
-[project.json]
-indent_size = 2
-
 # C# files
 [*.cs]
 end_of_line = lf
@@ -22,7 +19,7 @@ indent_style = tab
 tab_width = 4
 
 # New line preferences
-csharp_new_line_before_open_brace = types:methods
+csharp_new_line_before_open_brace = methods, types
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
@@ -44,9 +41,9 @@ dotnet_style_qualification_for_method = false:suggestion
 dotnet_style_qualification_for_event = false:suggestion
 
 # only use var when it's obvious what the variable type is
-csharp_style_var_for_built_in_types = false:none
-csharp_style_var_when_type_is_apparent = false:none
-csharp_style_var_elsewhere = false:suggestion
+csharp_style_var_for_built_in_types = true:none
+csharp_style_var_when_type_is_apparent = true:none
+csharp_style_var_elsewhere = true:suggestion
 
 # use language keywords instead of BCL types
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
@@ -70,7 +67,7 @@ dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_sty
 dotnet_naming_symbols.static_fields.applicable_kinds   = field
 dotnet_naming_symbols.static_fields.required_modifiers = static
 
-dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.required_prefix =
 dotnet_naming_style.static_prefix_style.capitalization = camel_case 
 
 # internal and private fields should be _camelCase
@@ -81,7 +78,7 @@ dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_
 dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
 dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
 
-dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.required_prefix =
 dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case 
 
 # Code style defaults
@@ -146,6 +143,7 @@ indent_brace_style = Allman
 [*.{csproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
 indent_size = 2
 end_of_line = crlf
+indent_style = space
 
 # Xml build files
 [*.builds]

--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,12 @@ srcnuget: sqlite-net.nuspec $(SRC)
 pclnuget: sqlite-net-pcl.nuspec packages $(SRC)
 	msbuild "/p:Configuration=Release" nuget/SQLite-net/SQLite-net.csproj
 	msbuild "/p:Configuration=Release" nuget/SQLite-net-std/SQLite-net-std.csproj 
-	nuget pack sqlite-net-pcl.nuspec -o .\
+	nuget pack sqlite-net-pcl.nuspec
 
 basenuget: sqlite-net-pcl.nuspec packages $(SRC)
 	msbuild "/p:Configuration=Release" nuget/SQLite-net-base/SQLite-net-base.csproj 
-	nuget pack sqlite-net-base.nuspec -o .\
+	nuget pack sqlite-net-base.nuspec
 
 sqlciphernuget: sqlite-net-sqlcipher.nuspec packages $(SRC)
 	msbuild "/p:Configuration=Release" nuget/SQLite-net-sqlcipher/SQLite-net-sqlcipher.csproj 
-	nuget pack sqlite-net-sqlcipher.nuspec -o .\
+	nuget pack sqlite-net-sqlcipher.nuspec

--- a/README.md
+++ b/README.md
@@ -3,7 +3,14 @@
 
 [![Build Status](https://app.bitrise.io/app/bf752c26c31aec6c/status.svg?token=puU-yHhMNdAwJUusm9swlA&branch=master)](https://app.bitrise.io/app/bf752c26c31aec6c)
 
-SQLite-net is an open source, minimal library to allow .NET and Mono applications to store data in
+Use one of these packages:
+
+| Version | Package | Description |
+| ------- | ------- | ----------- |
+| [![NuGet Package](https://img.shields.io/nuget/v/sqlite-net-pcl.svg)](https://www.nuget.org/packages/sqlite-net-pcl) | [sqlite-net-pcl](https://www.nuget.org/packages/sqlite-net-pcl) | .NET Standard Library |
+| [![NuGet Package with Encryption](https://img.shields.io/nuget/v/sqlite-net-sqlcipher.svg)](https://www.nuget.org/packages/sqlite-net-sqlcipher) | [sqlite-net-sqlcipher](https://www.nuget.org/packages/sqlite-net-sqlcipher) | With Encryption Support |
+
+SQLite-net is an open source, minimal library to allow .NET, .NET Core, and Mono applications to store data in
 [SQLite 3 databases](http://www.sqlite.org). It was first designed to work with [Xamarin.iOS](http://xamarin.com),
 but has since grown up to work on all the platforms (Xamarin.*, .NET, UWP, Azure, etc.).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # SQLite-net
 
-[![Build Status](https://www.bitrise.io/app/bf752c26c31aec6c.svg?token=puU-yHhMNdAwJUusm9swlA&branch=master)](https://www.bitrise.io/app/bf752c26c31aec6c)
+[![Build Status](https://app.bitrise.io/app/bf752c26c31aec6c/status.svg?token=puU-yHhMNdAwJUusm9swlA&branch=master)](https://app.bitrise.io/app/bf752c26c31aec6c)
 
 SQLite-net is an open source, minimal library to allow .NET and Mono applications to store data in
 [SQLite 3 databases](http://www.sqlite.org). It was first designed to work with [Xamarin.iOS](http://xamarin.com),

--- a/SQLite.sln
+++ b/SQLite.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		sqlite-net.nuspec = sqlite-net.nuspec
 		Makefile = Makefile
 		sqlite-net-base.nuspec = sqlite-net-base.nuspec
+		sqlite-net-sqlcipher.nuspec = sqlite-net-sqlcipher.nuspec
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SQLite-net", "nuget\SQLite-net\SQLite-net.csproj", "{7F946494-8EE0-432B-8A87-98961143D5C1}"

--- a/SQLite.sln
+++ b/SQLite.sln
@@ -10,6 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Makefile = Makefile
 		sqlite-net-base.nuspec = sqlite-net-base.nuspec
 		sqlite-net-sqlcipher.nuspec = sqlite-net-sqlcipher.nuspec
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SQLite-net", "nuget\SQLite-net\SQLite-net.csproj", "{7F946494-8EE0-432B-8A87-98961143D5C1}"

--- a/nuget/SQLite-net-base/SQLite-net-base.csproj
+++ b/nuget/SQLite-net-base/SQLite-net-base.csproj
@@ -30,6 +30,6 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SQLitePCLRaw.core" Version="1.1.8" />
+    <PackageReference Include="SQLitePCLRaw.core" Version="1.1.11" />
   </ItemGroup>
 </Project>

--- a/nuget/SQLite-net-sqlcipher/SQLite-net-sqlcipher.csproj
+++ b/nuget/SQLite-net-sqlcipher/SQLite-net-sqlcipher.csproj
@@ -22,7 +22,7 @@
     <DocumentationFile>bin\Debug\netstandard1.1\SQLite-net.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SQLitePCLRaw.bundle_sqlcipher" Version="1.1.8" />
+    <PackageReference Include="SQLitePCLRaw.bundle_sqlcipher" Version="1.1.11" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\src\SQLite.cs">

--- a/nuget/SQLite-net-std/SQLite-net-std.csproj
+++ b/nuget/SQLite-net-std/SQLite-net-std.csproj
@@ -22,7 +22,7 @@
     <DocumentationFile>bin\Debug\netstandard1.1\SQLite-net.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="1.1.8" />
+    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="1.1.11" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\src\SQLite.cs">

--- a/nuget/SQLite-net-std/SQLite-net-std.csproj
+++ b/nuget/SQLite-net-std/SQLite-net-std.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.1</TargetFramework>
     <AssemblyName>SQLite-net</AssemblyName>
-    <Version>1.0.0</Version>
+    <Version>1.5.232</Version>
     <AssemblyTitle>SQLite-net Official .NET Standard Library</AssemblyTitle>
     <Description>Light weight library providing easy SQLite database storage</Description>
     <Company>Krueger Systems, Inc.</Company>

--- a/nuget/SQLite-net/SQLite-net.csproj
+++ b/nuget/SQLite-net/SQLite-net.csproj
@@ -56,13 +56,13 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="SQLitePCLRaw.core">
-      <HintPath>..\..\packages\SQLitePCLRaw.core.1.1.8\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCLRaw.core.dll</HintPath>
+      <HintPath>..\..\packages\SQLitePCLRaw.core.1.1.11\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCLRaw.core.dll</HintPath>
     </Reference>
     <Reference Include="SQLitePCLRaw.batteries_green">
-      <HintPath>..\..\packages\SQLitePCLRaw.bundle_green.1.1.8\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCLRaw.batteries_green.dll</HintPath>
+      <HintPath>..\..\packages\SQLitePCLRaw.bundle_green.1.1.11\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCLRaw.batteries_green.dll</HintPath>
     </Reference>
     <Reference Include="SQLitePCLRaw.batteries_v2">
-      <HintPath>..\..\packages\SQLitePCLRaw.bundle_green.1.1.8\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCLRaw.batteries_v2.dll</HintPath>
+      <HintPath>..\..\packages\SQLitePCLRaw.bundle_green.1.1.11\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCLRaw.batteries_v2.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/nuget/SQLite-net/packages.config
+++ b/nuget/SQLite-net/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SQLitePCLRaw.bundle_green" version="1.1.8" targetFramework="portable45-net45+win8+wp8+wpa81" />
-  <package id="SQLitePCLRaw.core" version="1.1.8" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="SQLitePCLRaw.bundle_green" version="1.1.11" targetFramework="portable45-net45+win8+wp8+wpa81" />
+  <package id="SQLitePCLRaw.core" version="1.1.11" targetFramework="portable45-net45+win8+wp8+wpa81" />
 </packages>

--- a/sqlite-net-base.nuspec
+++ b/sqlite-net-base.nuspec
@@ -20,44 +20,44 @@
     <releaseNotes>See project page</releaseNotes>
     <dependencies>
       <group targetFramework="net">
-        <dependency id="SQLitePCLRaw.core" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.core" version="1.1.11" />
       </group>
       <group targetFramework="win">
-        <dependency id="SQLitePCLRaw.core" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.core" version="1.1.11" />
       </group>
       <group targetFramework="wp">
-        <dependency id="SQLitePCLRaw.core" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.core" version="1.1.11" />
       </group>
       <group targetFramework="wpa">
-        <dependency id="SQLitePCLRaw.core" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.core" version="1.1.11" />
       </group>
       <group targetFramework="netstandard1.1">
-        <dependency id="SQLitePCLRaw.core" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.core" version="1.1.11" />
         <dependency id="NETStandard.Library" version="1.6.1" />
       </group>
       <group targetFramework="MonoAndroid10">
-        <dependency id="SQLitePCLRaw.core" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.core" version="1.1.11" />
       </group>
       <group targetFramework="Xamarin.iOS10">
-        <dependency id="SQLitePCLRaw.core" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.core" version="1.1.11" />
       </group>
       <group targetFramework="Xamarin.Mac20">
-        <dependency id="SQLitePCLRaw.core" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.core" version="1.1.11" />
       </group>
       <group targetFramework="portable-net45+win+wpa81+wp80">
-        <dependency id="SQLitePCLRaw.core" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.core" version="1.1.11" />
       </group>
       <group targetFramework="uap">
-        <dependency id="SQLitePCLRaw.core" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.core" version="1.1.11" />
       </group>
       <group targetFramework="dotnet">
-        <dependency id="SQLitePCLRaw.core" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.core" version="1.1.11" />
       </group>
       <group targetFramework="xamarintvos">
-        <dependency id="SQLitePCLRaw.core" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.core" version="1.1.11" />
       </group>
       <group targetFramework="xamarinwatchos">
-        <dependency id="SQLitePCLRaw.core" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.core" version="1.1.11" />
       </group>
     </dependencies>
   </metadata>

--- a/sqlite-net-pcl.nuspec
+++ b/sqlite-net-pcl.nuspec
@@ -16,44 +16,44 @@
     <releaseNotes>See project page</releaseNotes>
     <dependencies>
       <group targetFramework="net">
-        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.11" />
       </group>
       <group targetFramework="win">
-        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.11" />
       </group>
       <group targetFramework="wp">
-        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.11" />
       </group>
       <group targetFramework="wpa">
-        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.11" />
       </group>
       <group targetFramework="netstandard1.1">
-        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.11" />
         <dependency id="NETStandard.Library" version="1.6.1" />
       </group>
       <group targetFramework="MonoAndroid10">
-        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.11" />
       </group>
       <group targetFramework="Xamarin.iOS10">
-        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.11" />
       </group>
       <group targetFramework="Xamarin.Mac20">
-        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.11" />
       </group>
       <group targetFramework="portable-net45+win+wpa81+wp80">
-        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.11" />
       </group>
       <group targetFramework="uap">
-        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.11" />
       </group>
       <group targetFramework="dotnet">
-        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.11" />
       </group>
       <group targetFramework="xamarintvos">
-        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.11" />
       </group>
       <group targetFramework="xamarinwatchos">
-        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_green" version="1.1.11" />
       </group>
     </dependencies>
   </metadata>

--- a/sqlite-net-sqlcipher.nuspec
+++ b/sqlite-net-sqlcipher.nuspec
@@ -16,44 +16,44 @@
     <releaseNotes>See project page</releaseNotes>
     <dependencies>
       <group targetFramework="net">
-        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.11" />
       </group>
       <group targetFramework="win">
-        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.11" />
       </group>
       <group targetFramework="wp">
-        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.11" />
       </group>
       <group targetFramework="wpa">
-        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.11" />
       </group>
       <group targetFramework="netstandard1.1">
-        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.11" />
         <dependency id="NETStandard.Library" version="1.6.1" />
       </group>
       <group targetFramework="MonoAndroid10">
-        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.11" />
       </group>
       <group targetFramework="Xamarin.iOS10">
-        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.11" />
       </group>
       <group targetFramework="Xamarin.Mac20">
-        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.11" />
       </group>
       <group targetFramework="portable-net45+win+wpa81+wp80">
-        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.11" />
       </group>
       <group targetFramework="uap">
-        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.11" />
       </group>
       <group targetFramework="dotnet">
-        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.11" />
       </group>
       <group targetFramework="xamarintvos">
-        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.11" />
       </group>
       <group targetFramework="xamarinwatchos">
-        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.8" />
+        <dependency id="SQLitePCLRaw.bundle_sqlcipher" version="1.1.11" />
       </group>
     </dependencies>
   </metadata>

--- a/src/AssemblyInfo.cs
+++ b/src/AssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.5.232.0")]
+[assembly: AssemblyFileVersion("1.5.232.0")]

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2009-2017 Krueger Systems, Inc.
+// Copyright (c) 2009-2018 Krueger Systems, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -228,8 +228,11 @@ namespace SQLite
 		/// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
 		/// the storeDateTimeAsTicks parameter.
 		/// </param>
-		public SQLiteConnection (string databasePath, bool storeDateTimeAsTicks = true)
-			: this (databasePath, SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create, storeDateTimeAsTicks)
+		/// <param name="key">
+		/// Specifies the encryption key to use on the database. Should be a string or a byte[].
+		/// </param>
+		public SQLiteConnection (string databasePath, bool storeDateTimeAsTicks = true, object key = null)
+			: this (databasePath, SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create, storeDateTimeAsTicks, key: key)
 		{
 		}
 
@@ -250,7 +253,10 @@ namespace SQLite
 		/// If you use DateTimeOffset properties, it will be always stored as ticks regardingless
 		/// the storeDateTimeAsTicks parameter.
 		/// </param>
-		public SQLiteConnection (string databasePath, SQLiteOpenFlags openFlags, bool storeDateTimeAsTicks = true)
+		/// <param name="key">
+		/// Specifies the encryption key to use on the database. Should be a string or a byte[].
+		/// </param>
+		public SQLiteConnection (string databasePath, SQLiteOpenFlags openFlags, bool storeDateTimeAsTicks = true, object key = null)
 		{
 			if (databasePath==null)
 				throw new ArgumentException ("Must be specified", nameof(databasePath));
@@ -284,10 +290,20 @@ namespace SQLite
 			StoreDateTimeAsTicks = storeDateTimeAsTicks;
 
 			BusyTimeout = TimeSpan.FromSeconds (0.1);
+			Tracer = line => Debug.WriteLine (line);
+
+			if (key is string stringKey) {
+				SetKey (stringKey);
+			}
+			else if (key is byte[] bytesKey) {
+				SetKey (bytesKey);
+			}
+			else if (key != null) {
+				throw new ArgumentException ("Encryption keys must be strings or byte arrays", nameof (key));
+			}
 			if (openFlags.HasFlag (SQLiteOpenFlags.ReadWrite)) {
 				ExecuteScalar<string> ("PRAGMA journal_mode=WAL");
 			}
-			Tracer = line => Debug.WriteLine (line);
 		}
 
 		/// <summary>
@@ -304,13 +320,13 @@ namespace SQLite
 		}
 
 		/// <summary>
-		/// Sets the key used to encrypt/decrypt the database.
+		/// Sets the key used to encrypt/decrypt the database with "pragma key = ...".
 		/// This must be the first thing you call before doing anything else with this connection
 		/// if your database is encrypted.
 		/// This only has an effect if you are using the SQLCipher nuget package.
 		/// </summary>
 		/// <param name="key">Ecryption key plain text that is converted to the real encryption key using PBKDF2 key derivation</param>
-		public void SetKey (string key)
+		void SetKey (string key)
 		{
 			if (key == null) throw new ArgumentNullException (nameof (key));
 			var q = Quote (key);
@@ -324,7 +340,7 @@ namespace SQLite
 		/// This only has an effect if you are using the SQLCipher nuget package.
 		/// </summary>
 		/// <param name="key">256-bit (32 byte) ecryption key data</param>
-		public void SetKey (byte[] key)
+		void SetKey (byte[] key)
 		{
 			if (key == null) throw new ArgumentNullException (nameof (key));
 			if (key.Length != 32) throw new ArgumentException ("Key must be 32 bytes (256-bit)", nameof(key));
@@ -2021,6 +2037,7 @@ namespace SQLite
 		public string ConnectionString { get; private set; }
 		public string DatabasePath { get; private set; }
 		public bool StoreDateTimeAsTicks { get; private set; }
+		public object Key { get; private set; }
 
 #if NETFX_CORE
 		static readonly string MetroStyleDataPath = Windows.Storage.ApplicationData.Current.LocalFolder.Path;
@@ -2038,10 +2055,11 @@ namespace SQLite
 
 #endif
 
-		public SQLiteConnectionString (string databasePath, bool storeDateTimeAsTicks)
+		public SQLiteConnectionString (string databasePath, bool storeDateTimeAsTicks, object key)
 		{
 			ConnectionString = databasePath;
 			StoreDateTimeAsTicks = storeDateTimeAsTicks;
+			Key = key;
 
 #if NETFX_CORE
 			DatabasePath = IsInMemoryPath(databasePath)

--- a/src/SQLite.cs
+++ b/src/SQLite.cs
@@ -2600,7 +2600,7 @@ namespace SQLite
 
 		public string CommandText { get; set; }
 
-		internal SQLiteCommand (SQLiteConnection conn)
+		public SQLiteCommand (SQLiteConnection conn)
 		{
 			_conn = conn;
 			_bindings = new List<Binding> ();
@@ -2658,8 +2658,6 @@ namespace SQLite
 		/// <remarks>
 		/// This can be overridden in combination with the <see cref="SQLiteConnection.NewCommand"/>
 		/// method to hook into the life-cycle of objects.
-		///
-		/// Type safety is not possible because MonoTouch does not support virtual generic methods.
 		/// </remarks>
 		protected virtual void OnInstanceCreated (object obj)
 		{
@@ -2780,7 +2778,7 @@ namespace SQLite
 			}
 		}
 
-		internal static IntPtr NegativePointer = new IntPtr (-1);
+		static IntPtr NegativePointer = new IntPtr (-1);
 
 		const string DateTimeExactStoreFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff";
 

--- a/tests/SQLCipherTest.cs
+++ b/tests/SQLCipherTest.cs
@@ -31,19 +31,15 @@ namespace SQLite.Tests
 
 			var key = "SecretPassword";
 
-			using (var db = new TestDb ()) {
+			using (var db = new TestDb (key: key)) {
 				path = db.DatabasePath;
-
-				db.SetKey (key);
 
 				db.CreateTable<TestTable> ();
 				db.Insert (new TestTable { Value = "Hello" });
 			}
 
-			using (var db = new TestDb (path)) {
+			using (var db = new TestDb (path, key: key)) {
 				path = db.DatabasePath;
-
-				db.SetKey (key);
 
 				var r = db.Table<TestTable> ().First ();
 
@@ -60,19 +56,15 @@ namespace SQLite.Tests
 			var key = new byte[32];
 			rand.NextBytes (key);
 
-			using (var db = new TestDb ()) {
+			using (var db = new TestDb (key: key)) {
 				path = db.DatabasePath;
-
-				db.SetKey (key);
 
 				db.CreateTable<TestTable> ();
 				db.Insert (new TestTable { Value = "Hello" });
 			}
 
-			using (var db = new TestDb (path)) {
+			using (var db = new TestDb (path, key: key)) {
 				path = db.DatabasePath;
-
-				db.SetKey (key);
 
 				var r = db.Table<TestTable> ().First ();
 
@@ -81,11 +73,29 @@ namespace SQLite.Tests
 		}
 
 		[Test]
+		public void SetEmptyStringKey ()
+		{
+			using (var db = new TestDb (key: "")) {
+			}
+		}
+
+		[Test]
+		public void SetBadTypeKey ()
+		{
+			try {
+				using (var db = new TestDb (key: 42)) {
+				}
+				Assert.Fail ("Should have thrown");
+			}
+			catch (ArgumentException) {
+			}
+		}
+
+		[Test]
 		public void SetBadBytesKey ()
 		{
 			try {
-				using (var db = new TestDb ()) {
-					db.SetKey (new byte[] { 1, 2, 3, 4 });
+				using (var db = new TestDb (key: new byte[] { 1, 2, 3, 4 })) {
 				}
 				Assert.Fail ("Should have thrown");
 			}

--- a/tests/TestDb.cs
+++ b/tests/TestDb.cs
@@ -53,12 +53,12 @@ namespace SQLite.Tests
 
 	public class TestDb : SQLiteConnection
 	{
-		public TestDb (bool storeDateTimeAsTicks = true) : base (TestPath.GetTempFileName (), storeDateTimeAsTicks)
+		public TestDb (bool storeDateTimeAsTicks = true, object key = null) : base (TestPath.GetTempFileName (), storeDateTimeAsTicks, key: key)
 		{
 			Trace = true;
 		}
 
-		public TestDb (string path, bool storeDateTimeAsTicks = true) : base (path, storeDateTimeAsTicks)
+		public TestDb (string path, bool storeDateTimeAsTicks = true, object key = null) : base (path, storeDateTimeAsTicks, key: key)
 		{
 			Trace = true;
 		}


### PR DESCRIPTION
Related to [JIRA TR-3206](https://teamnorthwoods.atlassian.net/browse/TR-3206)

While testing TR-3206, we were consistently getting memory access violation exceptions after the UWP migration. After some research we discovered that there was an [issue upstream that was fixed and released](https://github.com/praeclarum/sqlite-net/issues/667) as a part of [`sqlite-net`](https://github.com/praeclarum/sqlite-net) 1.5.

We pulled that in to our local fork with the changes we have to use UTC.

We do not want to PR this upstream at the moment without having a flag to enable UTC support so that we do not break other users reliant on the current behavior.

## NOTE
**This version, 1.5.232, exists on the Nexus Repository Manager only. You will need to add http://172.31.15.40:8081/repository/NorthwoodsPD-Nuget/ as a NuGet source before pulling.**